### PR TITLE
Remove stalled job if implementation not found

### DIFF
--- a/src/Services/QueuedJobService.php
+++ b/src/Services/QueuedJobService.php
@@ -470,6 +470,13 @@ class QueuedJobService
         /** @var QueuedJobDescriptor $stalledJob */
         foreach ($stalledJobs as $stalledJob) {
             $jobClass = $stalledJob->Implementation;
+            
+            if (!class_exists($jobClass)) {
+                $stalledJob->delete();
+
+                continue;
+            }
+            
             $jobSingleton = singleton($jobClass);
 
             if ($jobSingleton instanceof RunBuildTaskJob) {


### PR DESCRIPTION
If a job class is renamed or removed, remove the related stalled jobs rather than throwing an exception (which prevents the rest of the jobs from running).